### PR TITLE
fix: tablist not consistently showing all players

### DIFF
--- a/test/network/tab-list.test.ts
+++ b/test/network/tab-list.test.ts
@@ -15,6 +15,7 @@ function trackPlayerLogin(uuid: string, username: string, socket?: any) {
 
 describe('tab-list', () => {
   beforeEach(() => {
+    enableModule(OnlinePlayersModule);
     enableModule(TabListModule);
   });
 


### PR DESCRIPTION
- Add broadcastPlayerLeave() call when player disconnects
- Broadcast leave message to all other players on disconnect
- Re-broadcast player to all others after server switch
- Refresh tab list for switching player after switch completes
- Clean up profile properties when player leaves
- Use getPlayerSocket() for testability
- Enable OnlinePlayersModule in tab-list tests for hooks

Fixes #1

🤖 Generated with AI assistance