### PR TITLE
fix: prevent stale join messages accumulating on failed connections

### DIFF
--- a/network/proxy.ts
+++ b/network/proxy.ts
@@ -294,6 +294,13 @@ function flushPendingJoinMessages(): void {
   }
 }
 
+function removePendingJoinMessage(username: string): void {
+  const index = pendingJoinMessages.indexOf(username);
+  if (index !== -1) {
+    pendingJoinMessages.splice(index, 1);
+  }
+}
+
 function _broadcastLeaveMessage(username: string): void {
   const results = executeHook(FeatureHook.PlayerLeftMessage, { username });
   const message = results.find((r) => r);
@@ -1235,6 +1242,8 @@ export function createProxy(params: { target: number; port: number; onStatusRequ
 
       clientSocket.on('close', () => {
         if (trackedPlayer) {
+          // Remove pending join message if player disconnected before reaching play state
+          removePendingJoinMessage(trackedPlayer.username);
           trackConnectionClose(trackedPlayer.uuid);
           playerSwitcher.delete(trackedPlayer.uuid);
         }


### PR DESCRIPTION
## Summary
Fixes join messages from failed connection attempts accumulating and being sent all at once when the next player successfully joins.

## Changes
- Add `removePendingJoinMessage()` function to clean up pending join messages
- Call it when a player disconnects before reaching play state

## Problem
When someone fails to join, their join message was added to `pendingJoinMessages` but never removed if the connection failed. These accumulated messages were then all sent when the next player successfully joined.

## Solution
Clean up the pending join message when a player disconnects, preventing stale messages from accumulating.

Fixes #8

---
🤖 *Generated with AI assistance*