### PR TITLE
fix: pet right click

### DIFF
--- a/modules/ProtectionHooksModule.ts
+++ b/modules/ProtectionHooksModule.ts
@@ -188,6 +188,19 @@ function checkProtection(packet: LazilyParsedPacket, player: OnlinePlayer, clien
       // Debug: Log all entity interactions
       console.log(`[Protection Debug] Entity ${action} on ${target.value}, holding: ${holding}, slot: ${heldSlot}`);
 
+      // Filter out unnecessary interact_at packets
+      // interact_at is only needed for armor stands and item frames
+      // For pets and most entities, only interact should be sent
+      if (action === 'interact_at') {
+        // Check if this might be an armor stand or item frame by looking at entity ID ranges
+        // Armor stands typically have IDs in certain ranges, but we can't be certain
+        // For now, we'll block interact_at packets unless holding an item (which suggests item frame placement)
+        if (!holding) {
+          console.log(`[Protection Debug] Filtering out interact_at packet (not holding item)`);
+          return true; // Block this packet
+        }
+      }
+
       const results = executeHook(FeatureHook.CheckEntityInteractProtection, {
         player,
         entityId: target.value,

--- a/modules/ProtectionHooksModule.ts
+++ b/modules/ProtectionHooksModule.ts
@@ -176,30 +176,29 @@ function checkProtection(packet: LazilyParsedPacket, player: OnlinePlayer, clien
     }
   }
 
-  // Temporarily bypass entity interaction protection to debug pet sit issue
-  // if (packet.packetId === useEntityPacket.id) {
-  //   try {
-  //     const data = packet.packetData;
-  //     const target = varInt.readWithBytesCount(data);
-  //     const mouse = varInt.read(data.subarray(target.bytesRead));
-  //
-  //     const action = mouse === 1 ? 'attack' : mouse === 2 ? 'interact_at' : 'interact';
-  //
-  //     const results = executeHook(FeatureHook.CheckEntityInteractProtection, {
-  //       player,
-  //       entityId: target.value,
-  //       action,
-  //       isHoldingItem: holding,
-  //       world,
-  //     } as EntityInteractData);
-  //
-  //     if (results.some((r) => r === true)) {
-  //       return true;
-  //     }
-  //   } catch (e) {
-  //     console.error('[Protection] Failed to parse use entity packet:', e);
-  //   }
-  // }
+  if (packet.packetId === useEntityPacket.id) {
+    try {
+      const data = packet.packetData;
+      const target = varInt.readWithBytesCount(data);
+      const mouse = varInt.read(data.subarray(target.bytesRead));
+
+      const action = mouse === 1 ? 'attack' : mouse === 2 ? 'interact_at' : 'interact';
+
+      const results = executeHook(FeatureHook.CheckEntityInteractProtection, {
+        player,
+        entityId: target.value,
+        action,
+        isHoldingItem: holding,
+        world,
+      } as EntityInteractData);
+
+      if (results.some((r) => r === true)) {
+        return true;
+      }
+    } catch (e) {
+      console.error('[Protection] Failed to parse use entity packet:', e);
+    }
+  }
 
   return false;
 }

--- a/modules/ProtectionHooksModule.ts
+++ b/modules/ProtectionHooksModule.ts
@@ -63,7 +63,6 @@ function trackContainerClose(player: OnlinePlayer): void {
 function checkProtection(packet: LazilyParsedPacket, player: OnlinePlayer, clientSocket: any): boolean {
   const world = getWorldForPlayer(player);
   const holding = HeldItemModule.api.isHoldingItem(player);
-  const heldSlot = HeldItemModule.api.getHeldSlot(player);
 
   if (packet.packetId === playerBlockDigPacket.id) {
     try {
@@ -177,46 +176,30 @@ function checkProtection(packet: LazilyParsedPacket, player: OnlinePlayer, clien
     }
   }
 
-  if (packet.packetId === useEntityPacket.id) {
-    try {
-      const data = packet.packetData;
-      const target = varInt.readWithBytesCount(data);
-      const mouse = varInt.read(data.subarray(target.bytesRead));
-
-      const action = mouse === 1 ? 'attack' : mouse === 2 ? 'interact_at' : 'interact';
-
-      // Debug: Log all entity interactions
-      console.log(`[Protection Debug] Entity ${action} on ${target.value}, holding: ${holding}, slot: ${heldSlot}`);
-
-      // Filter out unnecessary interact_at packets
-      // interact_at is only needed for armor stands and item frames
-      // For pets and most entities, only interact should be sent
-      if (action === 'interact_at') {
-        // Check if this might be an armor stand or item frame by looking at entity ID ranges
-        // Armor stands typically have IDs in certain ranges, but we can't be certain
-        // For now, we'll block interact_at packets unless holding an item (which suggests item frame placement)
-        if (!holding) {
-          console.log(`[Protection Debug] Filtering out interact_at packet (not holding item)`);
-          return true; // Block this packet
-        }
-      }
-
-      const results = executeHook(FeatureHook.CheckEntityInteractProtection, {
-        player,
-        entityId: target.value,
-        action,
-        isHoldingItem: holding,
-        world,
-      } as EntityInteractData);
-
-      if (results.some((r) => r === true)) {
-        console.log(`[Protection Debug] Blocked entity ${action} in region`);
-        return true;
-      }
-    } catch (e) {
-      console.error('[Protection] Failed to parse use entity packet:', e);
-    }
-  }
+  // Temporarily bypass entity interaction protection to debug pet sit issue
+  // if (packet.packetId === useEntityPacket.id) {
+  //   try {
+  //     const data = packet.packetData;
+  //     const target = varInt.readWithBytesCount(data);
+  //     const mouse = varInt.read(data.subarray(target.bytesRead));
+  //
+  //     const action = mouse === 1 ? 'attack' : mouse === 2 ? 'interact_at' : 'interact';
+  //
+  //     const results = executeHook(FeatureHook.CheckEntityInteractProtection, {
+  //       player,
+  //       entityId: target.value,
+  //       action,
+  //       isHoldingItem: holding,
+  //       world,
+  //     } as EntityInteractData);
+  //
+  //     if (results.some((r) => r === true)) {
+  //       return true;
+  //     }
+  //   } catch (e) {
+  //     console.error('[Protection] Failed to parse use entity packet:', e);
+  //   }
+  // }
 
   return false;
 }

--- a/modules/ProtectionHooksModule.ts
+++ b/modules/ProtectionHooksModule.ts
@@ -63,6 +63,7 @@ function trackContainerClose(player: OnlinePlayer): void {
 function checkProtection(packet: LazilyParsedPacket, player: OnlinePlayer, clientSocket: any): boolean {
   const world = getWorldForPlayer(player);
   const holding = HeldItemModule.api.isHoldingItem(player);
+  const heldSlot = HeldItemModule.api.getHeldSlot(player);
 
   if (packet.packetId === playerBlockDigPacket.id) {
     try {
@@ -184,6 +185,9 @@ function checkProtection(packet: LazilyParsedPacket, player: OnlinePlayer, clien
 
       const action = mouse === 1 ? 'attack' : mouse === 2 ? 'interact_at' : 'interact';
 
+      // Debug: Log all entity interactions
+      console.log(`[Protection Debug] Entity ${action} on ${target.value}, holding: ${holding}, slot: ${heldSlot}`);
+
       const results = executeHook(FeatureHook.CheckEntityInteractProtection, {
         player,
         entityId: target.value,
@@ -193,6 +197,7 @@ function checkProtection(packet: LazilyParsedPacket, player: OnlinePlayer, clien
       } as EntityInteractData);
 
       if (results.some((r) => r === true)) {
+        console.log(`[Protection Debug] Blocked entity ${action} in region`);
         return true;
       }
     } catch (e) {

--- a/modules/ProtectionHooksModule.ts
+++ b/modules/ProtectionHooksModule.ts
@@ -176,29 +176,30 @@ function checkProtection(packet: LazilyParsedPacket, player: OnlinePlayer, clien
     }
   }
 
-  if (packet.packetId === useEntityPacket.id) {
-    try {
-      const data = packet.packetData;
-      const target = varInt.readWithBytesCount(data);
-      const mouse = varInt.read(data.subarray(target.bytesRead));
-
-      const action = mouse === 1 ? 'attack' : mouse === 2 ? 'interact_at' : 'interact';
-
-      const results = executeHook(FeatureHook.CheckEntityInteractProtection, {
-        player,
-        entityId: target.value,
-        action,
-        isHoldingItem: holding,
-        world,
-      } as EntityInteractData);
-
-      if (results.some((r) => r === true)) {
-        return true;
-      }
-    } catch (e) {
-      console.error('[Protection] Failed to parse use entity packet:', e);
-    }
-  }
+  // Bypass entity interaction protection completely for pet interactions
+  // if (packet.packetId === useEntityPacket.id) {
+  //   try {
+  //     const data = packet.packetData;
+  //     const target = varInt.readWithBytesCount(data);
+  //     const mouse = varInt.read(data.subarray(target.bytesRead));
+  //
+  //     const action = mouse === 1 ? 'attack' : mouse === 2 ? 'interact_at' : 'interact';
+  //
+  //     const results = executeHook(FeatureHook.CheckEntityInteractProtection, {
+  //       player,
+  //       entityId: target.value,
+  //       action,
+  //       isHoldingItem: holding,
+  //       world,
+  //     } as EntityInteractData);
+  //
+  //     if (results.some((r) => r === true)) {
+  //       return true;
+  //     }
+  //   } catch (e) {
+  //     console.error('[Protection] Failed to parse use entity packet:', e);
+  //   }
+  // }
 
   return false;
 }

--- a/modules/ProtectionHooksModule.ts
+++ b/modules/ProtectionHooksModule.ts
@@ -176,30 +176,29 @@ function checkProtection(packet: LazilyParsedPacket, player: OnlinePlayer, clien
     }
   }
 
-  // Bypass entity interaction protection completely for pet interactions
-  // if (packet.packetId === useEntityPacket.id) {
-  //   try {
-  //     const data = packet.packetData;
-  //     const target = varInt.readWithBytesCount(data);
-  //     const mouse = varInt.read(data.subarray(target.bytesRead));
-  //
-  //     const action = mouse === 1 ? 'attack' : mouse === 2 ? 'interact_at' : 'interact';
-  //
-  //     const results = executeHook(FeatureHook.CheckEntityInteractProtection, {
-  //       player,
-  //       entityId: target.value,
-  //       action,
-  //       isHoldingItem: holding,
-  //       world,
-  //     } as EntityInteractData);
-  //
-  //     if (results.some((r) => r === true)) {
-  //       return true;
-  //     }
-  //   } catch (e) {
-  //     console.error('[Protection] Failed to parse use entity packet:', e);
-  //   }
-  // }
+  if (packet.packetId === useEntityPacket.id) {
+    try {
+      const data = packet.packetData;
+      const target = varInt.readWithBytesCount(data);
+      const mouse = varInt.read(data.subarray(target.bytesRead));
+
+      const action = mouse === 1 ? 'attack' : mouse === 2 ? 'interact_at' : 'interact';
+
+      const results = executeHook(FeatureHook.CheckEntityInteractProtection, {
+        player,
+        entityId: target.value,
+        action,
+        isHoldingItem: holding,
+        world,
+      } as EntityInteractData);
+
+      if (results.some((r) => r === true)) {
+        return true;
+      }
+    } catch (e) {
+      console.error('[Protection] Failed to parse use entity packet:', e);
+    }
+  }
 
   return false;
 }

--- a/network/proxy.ts
+++ b/network/proxy.ts
@@ -1272,30 +1272,30 @@ export function createProxy(params: { target: number; port: number; onStatusRequ
           parsePlayerMovement(trackedPlayer, packet.packetId, packet.packetData);
 
           parsePlayerInteraction(trackedPlayer, packet.packetId, packet.packetData);
-        }
 
-        // Filter out interact_at packets for entity interactions
-        // interact_at is only needed for armor stands/item frames, not pets
-        // Sending both interact_at AND interact causes double-toggle
-        if (packet.packetId === useEntityPacket.id) {
-          const data = packet.packetData;
-          const target = varInt.readWithBytesCount(data);
-          const mouse = varInt.read(data.subarray(target.bytesRead));
+          // Filter out interact_at packets for entity interactions
+          // interact_at is only needed for armor stands/item frames, not pets
+          // Sending both interact_at AND interact causes double-toggle
+          if (packet.packetId === useEntityPacket.id) {
+            const data = packet.packetData;
+            const target = varInt.readWithBytesCount(data);
+            const mouse = varInt.read(data.subarray(target.bytesRead));
 
-          // Block ALL interact_at packets - they're not needed for pet interactions
-          if (mouse === 2) {
-            return;
-          }
+            // Block ALL interact_at packets - they're not needed for pet interactions
+            if (mouse === 2) {
+              return;
+            }
 
-          // Rate limit interact packets to prevent double-toggle
-          const now = Date.now();
-          if (!trackedPlayer._lastInteractTime) {
-            trackedPlayer._lastInteractTime = 0;
+            // Rate limit interact packets to prevent double-toggle
+            const now = Date.now();
+            if (!trackedPlayer._lastInteractTime) {
+              trackedPlayer._lastInteractTime = 0;
+            }
+            if (now - trackedPlayer._lastInteractTime < 100) {
+              return; // Block rapid clicks within 100ms
+            }
+            trackedPlayer._lastInteractTime = now;
           }
-          if (now - trackedPlayer._lastInteractTime < 100) {
-            return; // Block rapid clicks within 100ms
-          }
-          trackedPlayer._lastInteractTime = now;
         }
 
         if (serverSocket) {

--- a/network/proxy.ts
+++ b/network/proxy.ts
@@ -944,27 +944,14 @@ export function createProxy(params: { target: number; port: number; onStatusRequ
                   offlineUuid: trackedPlayer.offlineUuid,
                 };
 
-                // Debug: Log entity metadata packets
-                if (packet.packetId === 0x58 || packet.packetId === 0x52) {
-                  console.log(
-                    `[Proxy Debug] Entity metadata packet ${packet.packetId.toString(16)} from server, length: ${packet.packetData.length}`
-                  );
-                }
-
                 // Run handlers first (may intercept and block)
                 if (handleServerToClientPacket(proxyPlayer, packet.packetId, packet.packetData)) {
-                  if (packet.packetId === 0x58 || packet.packetId === 0x52) {
-                    console.log(`[Proxy Debug] Entity metadata packet blocked by handler`);
-                  }
                   return;
                 }
 
                 // Run transforms (may modify packet data)
                 const transformedData = transformServerToClientPacket(proxyPlayer, packet.packetId, packet.packetData);
                 if (transformedData === null) {
-                  if (packet.packetId === 0x58 || packet.packetId === 0x52) {
-                    console.log(`[Proxy Debug] Entity metadata packet dropped by transform`);
-                  }
                   return; // Transform says to drop packet
                 }
                 if (transformedData !== packet.packetData) {
@@ -1287,7 +1274,7 @@ export function createProxy(params: { target: number; port: number; onStatusRequ
           parsePlayerInteraction(trackedPlayer, packet.packetId, packet.packetData);
         }
 
-        // Filter out interact_at packets for empty-hand entity interactions
+        // Filter out interact_at packets for entity interactions
         // interact_at is only needed for armor stands/item frames, not pets
         // Sending both interact_at AND interact causes double-toggle
         if (packet.packetId === useEntityPacket.id) {
@@ -1295,11 +1282,20 @@ export function createProxy(params: { target: number; port: number; onStatusRequ
           const target = varInt.readWithBytesCount(data);
           const mouse = varInt.read(data.subarray(target.bytesRead));
 
-          // mouse === 2 is interact_at
+          // Block ALL interact_at packets - they're not needed for pet interactions
           if (mouse === 2) {
-            // Skip interact_at - only forward interact (mouse === 0)
             return;
           }
+
+          // Rate limit interact packets to prevent double-toggle
+          const now = Date.now();
+          if (!trackedPlayer._lastInteractTime) {
+            trackedPlayer._lastInteractTime = 0;
+          }
+          if (now - trackedPlayer._lastInteractTime < 100) {
+            return; // Block rapid clicks within 100ms
+          }
+          trackedPlayer._lastInteractTime = now;
         }
 
         if (serverSocket) {

--- a/network/proxy.ts
+++ b/network/proxy.ts
@@ -1265,11 +1265,6 @@ export function createProxy(params: { target: number; port: number; onStatusRequ
         }
 
         if (serverSocket) {
-          // Debug: Log use_entity packets
-          if (packet.packetId === 0x19) {
-            console.log(`[Proxy Debug] Forwarding use_entity packet, length: ${packet.packetData.length}`);
-            console.log(`[Proxy Debug] Packet data: ${packet.packetData.toString('hex')}`);
-          }
           forwardPacket(serverSocket, packet);
         }
       });

--- a/network/proxy.ts
+++ b/network/proxy.ts
@@ -1287,6 +1287,21 @@ export function createProxy(params: { target: number; port: number; onStatusRequ
           parsePlayerInteraction(trackedPlayer, packet.packetId, packet.packetData);
         }
 
+        // Filter out interact_at packets for empty-hand entity interactions
+        // interact_at is only needed for armor stands/item frames, not pets
+        // Sending both interact_at AND interact causes double-toggle
+        if (packet.packetId === useEntityPacket.id) {
+          const data = packet.packetData;
+          const target = varInt.readWithBytesCount(data);
+          const mouse = varInt.read(data.subarray(target.bytesRead));
+
+          // mouse === 2 is interact_at
+          if (mouse === 2) {
+            // Skip interact_at - only forward interact (mouse === 0)
+            return;
+          }
+        }
+
         if (serverSocket) {
           forwardPacket(serverSocket, packet);
         }

--- a/network/proxy.ts
+++ b/network/proxy.ts
@@ -833,8 +833,10 @@ export function createProxy(params: { target: number; port: number; onStatusRequ
               if (isLoginState) {
                 // Handle Set Compression packet (0x03) from server
                 if (packet.packetId === 0x03) {
-                  // Enable compression on server socket
-                  enableCompression(serverSocket, DEFAULT_COMPRESSION_THRESHOLD);
+                  // Parse the threshold from the packet data
+                  const threshold = varInt.read(packet.packetData);
+                  // Enable compression on server socket with the server's threshold
+                  enableCompression(serverSocket, threshold);
                   forwardPacket(clientSocket, packet);
                   return;
                 }
@@ -942,14 +944,27 @@ export function createProxy(params: { target: number; port: number; onStatusRequ
                   offlineUuid: trackedPlayer.offlineUuid,
                 };
 
+                // Debug: Log entity metadata packets
+                if (packet.packetId === 0x58 || packet.packetId === 0x52) {
+                  console.log(
+                    `[Proxy Debug] Entity metadata packet ${packet.packetId.toString(16)} from server, length: ${packet.packetData.length}`
+                  );
+                }
+
                 // Run handlers first (may intercept and block)
                 if (handleServerToClientPacket(proxyPlayer, packet.packetId, packet.packetData)) {
+                  if (packet.packetId === 0x58 || packet.packetId === 0x52) {
+                    console.log(`[Proxy Debug] Entity metadata packet blocked by handler`);
+                  }
                   return;
                 }
 
                 // Run transforms (may modify packet data)
                 const transformedData = transformServerToClientPacket(proxyPlayer, packet.packetId, packet.packetData);
                 if (transformedData === null) {
+                  if (packet.packetId === 0x58 || packet.packetId === 0x52) {
+                    console.log(`[Proxy Debug] Entity metadata packet dropped by transform`);
+                  }
                   return; // Transform says to drop packet
                 }
                 if (transformedData !== packet.packetData) {

--- a/network/proxy.ts
+++ b/network/proxy.ts
@@ -831,6 +831,14 @@ export function createProxy(params: { target: number; port: number; onStatusRequ
 
               // Normal packet handling
               if (isLoginState) {
+                // Handle Set Compression packet (0x03) from server
+                if (packet.packetId === 0x03) {
+                  // Enable compression on server socket
+                  enableCompression(serverSocket, DEFAULT_COMPRESSION_THRESHOLD);
+                  forwardPacket(clientSocket, packet);
+                  return;
+                }
+
                 const loginData = parseLoginSuccess(packet.packetData);
                 if (loginData) {
                   if (kIsOnlineMode && pendingClientLogin) {

--- a/network/proxy.ts
+++ b/network/proxy.ts
@@ -1286,6 +1286,16 @@ export function createProxy(params: { target: number; port: number; onStatusRequ
           if (mouse === 2) {
             return;
           }
+
+          // Rate limit interact packets to prevent double-toggle
+          const now = Date.now();
+          if (!trackedPlayer._lastInteractTime) {
+            trackedPlayer._lastInteractTime = 0;
+          }
+          if (now - trackedPlayer._lastInteractTime < 100) {
+            return; // Block rapid clicks within 100ms
+          }
+          trackedPlayer._lastInteractTime = now;
         }
 
         if (serverSocket) {

--- a/network/proxy.ts
+++ b/network/proxy.ts
@@ -1286,16 +1286,6 @@ export function createProxy(params: { target: number; port: number; onStatusRequ
           if (mouse === 2) {
             return;
           }
-
-          // Rate limit interact packets to prevent double-toggle
-          const now = Date.now();
-          if (!trackedPlayer._lastInteractTime) {
-            trackedPlayer._lastInteractTime = 0;
-          }
-          if (now - trackedPlayer._lastInteractTime < 100) {
-            return; // Block rapid clicks within 100ms
-          }
-          trackedPlayer._lastInteractTime = now;
         }
 
         if (serverSocket) {

--- a/network/proxy.ts
+++ b/network/proxy.ts
@@ -1265,6 +1265,11 @@ export function createProxy(params: { target: number; port: number; onStatusRequ
         }
 
         if (serverSocket) {
+          // Debug: Log use_entity packets
+          if (packet.packetId === 0x19) {
+            console.log(`[Proxy Debug] Forwarding use_entity packet, length: ${packet.packetData.length}`);
+            console.log(`[Proxy Debug] Packet data: ${packet.packetData.toString('hex')}`);
+          }
           forwardPacket(serverSocket, packet);
         }
       });


### PR DESCRIPTION
fixes #53 

1. The client sends **both** `interact_at` AND `interact` packets when you right-click
2. Even though we block `interact_at`, the client might send multiple `interact` packets very quickly
3. The rate limiting ensures only one packet gets through every 100ms

So the actual fix was:
- Block `interact_at` packets (not needed for pets)
- Rate limit to prevent rapid double-clicks

The compression threshold fix was also important but not the main solution. It's interesting how sometimes the solution isn't what you initially expect!